### PR TITLE
bump mcp minimum to 1.23.0 to fix GHSA-3qhf-m339-9g5v, GHSA-9h52-p55h…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "platformdirs>=4.0.0",
-    "mcp>=1.9.0",
+    "mcp>=1.23.0",
     "typer>=0.12.0",
     "rich>=13.0.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
Bump mcp version for vulns